### PR TITLE
Agrega *.http al .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ packages/
 # Otros
 *.DS_Store
 Thumbs.db
+*.http


### PR DESCRIPTION
Este pull request agrega la extensión *.http al archivo .gitignore para evitar subir archivos de pruebas HTTP al repositorio.